### PR TITLE
Logo image custom size constraint.

### DIFF
--- a/assets/css/PITCHME.css
+++ b/assets/css/PITCHME.css
@@ -93,3 +93,5 @@ go on with your bad self!
         0 0 100px 60px #f0f, /* middle magenta */
         0 0 140px 90px #0ff; /* outer cyan */
 }
+
+#gp-logo img { max-height: 1.75em !important; }


### PR DESCRIPTION
Hi Oscar,

I was looking over the slide deck you recently [shared on Twitter](https://twitter.com/SharePointOscar/status/1240678526694518784) and wanted to share a little tip that will help you to control the size of the _CloudBees_ logo on your slides. Specifically a tweak to reduce the size of the logo to make a little more room for the content on your slides. As you can see in the diff for this PR I've simply activated a [custom CSS style rule](https://gitpitch.com/docs/themes/custom/) for the logo image.

You can see the effect of this small change in my version of your slide decks:

- [Workshop: Canary Deployments](https://gitpitch.com/gitpitch/presentations?p=workshops/canary-deployments)
- [Intro to Jenkins-X](https://gitpitch.com/gitpitch/presentations?p=talks/intro-to-jenkins-x)

Because these two decks are sharing the same `assets/css/PITCHME.css` file only one change was needed to activate this change in both decks. If you like the  change you are very welcome to merge this PR. And if not, please feel free to discard. Cheers, David.